### PR TITLE
new config: DEBUG_PROPAGATE_EXCEPTIONS

### DIFF
--- a/quixote/config.py
+++ b/quixote/config.py
@@ -62,6 +62,10 @@ DEBUG_LOG = None
 # for this setting.)
 DISPLAY_EXCEPTIONS = None
 
+# If set to True, Quixote will not catch exceptions, and
+# exceptions will propagate upwards.
+DEBUG_PROPAGATE_EXCEPTIONS = False
+
 # If true, then any "resource not found" errors will result in a
 # consistent, terse, mostly-useless message.  If false, then the
 # exact cause of failure will be returned.
@@ -196,6 +200,7 @@ class Config:
         'access_log',
         'debug_log',
         'display_exceptions',
+        'debug_propagate_exceptions',
         'secure_errors',
         'error_log',
         'run_once',

--- a/quixote/publish.py
+++ b/quixote/publish.py
@@ -546,9 +546,13 @@ class Publisher:
         except errors.PublishError, exc:
             # Exit the publishing loop and return a result right away.
             output = self.finish_interrupted_request(request, exc)
+            if self.config.debug_propagate_exceptions:
+                raise
         except:
             # Some other exception, generate error messages to the logs, etc.
             output = self.finish_failed_request(request)
+            if self.config.debug_propagate_exceptions:
+                raise
         output = self.filter_output(request, output)
         self.log_request(request)
         return output


### PR DESCRIPTION
If set to `True`, Quixote will not catch exceptions, and exceptions will propagate upwards.

It's useful for debugging application with Werkzeug Debugger.
